### PR TITLE
Was returning invalid for valid seed phrases

### DIFF
--- a/lib/src/bip39_base.dart
+++ b/lib/src/bip39_base.dart
@@ -55,7 +55,7 @@ String generateMnemonic({
 }
 String entropyToMnemonic(String entropyString) {
   final entropy = HEX.decode(entropyString);
-  if (entropy.length < 16) {
+  if (entropy.length < 4) {
     throw ArgumentError(_INVALID_ENTROPY);
   }
   if (entropy.length > 32) {
@@ -118,7 +118,7 @@ String mnemonicToEntropy (mnemonic) {
       .allMatches(entropyBits)
       .map((match) => _binaryToByte(match.group(0)))
       .toList(growable: false));
-  if (entropyBytes.length < 16) {
+  if (entropyBytes.length < 4) {
     throw StateError(_INVALID_ENTROPY);
   }
   if (entropyBytes.length > 32) {


### PR DESCRIPTION
Was returning invalid for the unsafe but valid seed phrase "venue muscle foot"

Short seed phrases are useful for testing purposes and devs should be checking and giving warning on minimum length not banning.