### PR TITLE
add support for passphrase protected seeds

### DIFF
--- a/lib/src/bip39_base.dart
+++ b/lib/src/bip39_base.dart
@@ -76,12 +76,12 @@ String entropyToMnemonic(String entropyString) {
   String words = chunks.map((binary) => wordlist[_binaryToByte(binary)]).join(' ');
   return words;
 }
-Uint8List mnemonicToSeed(String mnemonic) {
-  final pbkdf2 = new PBKDF2();
+Uint8List mnemonicToSeed(String mnemonic, {String passphrase = ''}) {
+  final pbkdf2 = new PBKDF2(salt: 'mnemonic' + passphrase);
   return pbkdf2.process(mnemonic);
 }
-String mnemonicToSeedHex(String mnemonic) {
-  return mnemonicToSeed(mnemonic).map((byte) {
+String mnemonicToSeedHex(String mnemonic, {String passphrase = ''}) {
+  return mnemonicToSeed(mnemonic, passphrase: passphrase).map((byte) {
     return byte.toRadixString(16).padLeft(2, '0');
   }).join('');
 }

--- a/test/bip39_test.dart
+++ b/test/bip39_test.dart
@@ -89,6 +89,7 @@ void testVector(List<dynamic> v, int i) {
   final ventropy = v[0];
   final vmnemonic = v[1];
   final vseedHex = v[2];
+  final passphrase = v.length > 3 ? v[3] : '';
   group('for English(${i}), ${ventropy}', () {
     setUp(() {});
     test('mnemoic to entropy', () {
@@ -96,7 +97,7 @@ void testVector(List<dynamic> v, int i) {
       expect(entropy, equals(ventropy));
     });
     test('mnemonic to seed hex', () {
-      final seedHex = bip39.mnemonicToSeedHex(vmnemonic);
+      final seedHex = bip39.mnemonicToSeedHex(vmnemonic, passphrase: passphrase);
       expect(seedHex, equals(vseedHex));
     });
     test('entropy to mnemonic', () {

--- a/test/vectors.json
+++ b/test/vectors.json
@@ -119,6 +119,12 @@
       "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
       "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
       "898c7388d88e3a5b3b2922a0f03f95c8e61aeadba9fa8a7b0b5629d7c98e1e0aec53f0b10fcbd4a913b4b8c985028b0026ec6fdb0a4442ee18344ca3fac4d692"
+    ],
+    [
+      "00000000000000000000000000000000",
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+      "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+      "TREZOR"
     ]
   ]
 }


### PR DESCRIPTION
According to [bip-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) seeds can be protected with a passphrase. However this package hardcodes the passphrase to '' (empty string).

This change adds a `passphrase` parameter to `mnemonicToSeed` and `mnemonicToSeedHex` so it can be set to other values.

Also added a test vector from the page linked in the spec .