### PR TITLE
chore(deps): bump pointycastle from ^3.0.0-nullsafety.2 to ^4.0.0

### DIFF
--- a/lib/src/utils/pbkdf2.dart
+++ b/lib/src/utils/pbkdf2.dart
@@ -18,14 +18,12 @@ class PBKDF2 {
     this.blockLength = 128,
     this.iterationCount = 2048,
     this.desiredKeyLength = 64,
-  }) : _derivator =
-            new PBKDF2KeyDerivator(new HMac(new SHA512Digest(), blockLength));
+  }) : _derivator = PBKDF2KeyDerivator(HMac(SHA512Digest(), blockLength));
 
-  Uint8List process(String mnemonic, {passphrase: ""}) {
+  Uint8List process(String mnemonic, {passphrase = ""}) {
     final salt = Uint8List.fromList(utf8.encode(saltPrefix + passphrase));
     _derivator.reset();
-    _derivator
-        .init(new Pbkdf2Parameters(salt, iterationCount, desiredKeyLength));
-    return _derivator.process(new Uint8List.fromList(mnemonic.codeUnits));
+    _derivator.init(Pbkdf2Parameters(salt, iterationCount, desiredKeyLength));
+    return _derivator.process(Uint8List.fromList(mnemonic.codeUnits));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  pointycastle: ^3.0.0-nullsafety.2
+  pointycastle: ^4.0.0
   hex: ^0.2.0
   crypto: ^3.0.0
 dev_dependencies:


### PR DESCRIPTION
### Description
- Updated dependency: bumped `pointycastle` from ^3.0.0-nullsafety.2 to ^4.0.0

### Motivation
- Upgrading ensures compatibility with the stable ^4.0.0 release
- This makes the library usable in new projects without dependency conflicts